### PR TITLE
Remove Ruby dependency, lock package versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 nodejs:
   - "5"
-before_install:
-  - rvm install 2.3.0
 install:
   - npm i
 notifications:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Typography based on Google's Material Design Standard; available in CSS, LESS, S
 #### NPM
 
 ```
-npm i --save material-typography
+npm install --save material-typography
 ```
 
 #### Bower

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Typography based on Google's Material Design Standard; available in CSS, LESS, SASS, SCSS, and Stylus.
 
-###### this package requires Ruby to be installed on your system and `PATH`
-
 ### Install Instructions
 
 #### NPM

--- a/package.json
+++ b/package.json
@@ -11,18 +11,17 @@
   "homepage": "https://github.com/juliancoleman/material-typography#readme",
   "license": "MIT",
   "scripts": {
-    "preinstall": "npm run installSass",
-    "suppath": "mkdir build; cd build/ && mkdir less sass scss styl",
+    "suppath": "mkdir -p build; cd build/ && mkdir -p less sass scss styl",
     "build:all": "concurrently \"npm run build:less\" \"npm run build:sass\" \"npm run build:scss\" \"npm run build:styl\" ",
     "build:less": "lessc -x less/typography.less build/less/typography.min.css",
-    "build:sass": "sass --style compressed --no-cache sass/typography.sass:build/sass/typography.min.css",
-    "build:scss": "sass --style compressed --no-cache scss/typography.scss:build/scss/typography.min.css",
+    "build:sass": "node-sass --style compressed --no-cache sass/typography.sass build/sass/typography.min.css",
+    "build:scss": "node-sass --style compressed --no-cache scss/typography.scss build/scss/typography.min.css",
     "build:styl": "stylus -c -r styl/typography.styl -o build/styl/typography.min.css",
-    "installSass": "gem install sass compass",
     "postinstall": "npm run suppath && npm run build:all"
   },
   "dependencies": {
     "less": "^2.6.1",
+    "node-sass": "~3.5.3",
     "stylus": "^0.54.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "postinstall": "npm run suppath && npm run build:all"
   },
   "dependencies": {
-    "less": "^2.6.1",
+    "less": "~2.6.1",
     "node-sass": "~3.5.3",
-    "stylus": "^0.54.2"
+    "stylus": "~0.54.2"
   },
   "devDependencies": {
-    "concurrently": "^2.0.0",
-    "scss-lint": "0.0.0"
+    "concurrently": "~2.0.0",
+    "scss-lint": "~0.0.0"
   }
 }


### PR DESCRIPTION
This PR is broken up into a few parts:
- Remove the Ruby dependency from the project. I was reading up [here](https://medium.com/@brianhan/watch-compile-your-sass-with-npm-9ba2b878415b) about using `node-sass` to build your sass/scss using npm scripts, and it seems to work well. I updated the npm scripts accordingly, and also updated the `suppath` step to use `mkdir -p` just in case the folders to be created already exist.
- I locked all of your packages using `~` to hopefully prevent any packages from breaking.
- A small change to the README for consistency, and removed Ruby PATH documentation

Let me know what you think @juliancoleman! 😄 

Edit: If you could pull this branch and make sure that the built CSS looks OK I'd appreciate it, it is passing Travis but that means nothing if the output is 💩  😆 